### PR TITLE
fix: madara latest chapters broken/manga name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,7 +188,7 @@ dependencies = [
 
 [[package]]
 name = "firstkissmanhua"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "madara",
@@ -330,7 +330,7 @@ dependencies = [
 
 [[package]]
 name = "isekaiscan"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "madara",
@@ -366,7 +366,7 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "leviatanscan"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "madara",
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "mmscans"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "madara",
@@ -894,7 +894,7 @@ dependencies = [
 
 [[package]]
 name = "reaperscan"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "madara",
@@ -1236,7 +1236,7 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tritiniascans"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "madara",

--- a/common/madara/src/lib.rs
+++ b/common/madara/src/lib.rs
@@ -28,7 +28,7 @@ pub fn parse_manga_list(
         } else {
             "div.item-summary > a > h3, div.data > h3 > a, div.post-title > h3 > a"
         })
-            .map_err(|e| anyhow!("failed to parse selector: {:?}", e))?;
+        .map_err(|e| anyhow!("failed to parse selector: {:?}", e))?;
 
         let selector_url = Selector::parse("div.data a, div.post-title a, div.item-thumb a")
             .map_err(|e| anyhow!("failed to parse selector: {:?}", e))?;
@@ -280,8 +280,8 @@ fn parse_chapters(
                     &format!("{} 00:00", chapter_time.trim()),
                     "%B %d, %Y %H:%M",
                 )
-                    .unwrap_or_else(|_| Utc::now().naive_utc())
-                    .timestamp(),
+                .unwrap_or_else(|_| Utc::now().naive_utc())
+                .timestamp(),
             }
         })
         .collect();

--- a/common/madara/src/lib.rs
+++ b/common/madara/src/lib.rs
@@ -24,11 +24,11 @@ pub fn parse_manga_list(
 
     for el in doc.select(selector) {
         let selector_name = Selector::parse(if is_selector_url {
-            "div.item-summary h3, div.data h3 a, div.post-title h3"
+            "div.item-summary > a > h3, div.data > h3 > a, div.post-title > h3"
         } else {
-            "div.item-summary h3, div.data h3 a, div.post-title a"
+            "div.item-summary > a > h3, div.data > h3 > a, div.post-title > h3 > a"
         })
-        .map_err(|e| anyhow!("failed to parse selector: {:?}", e))?;
+            .map_err(|e| anyhow!("failed to parse selector: {:?}", e))?;
 
         let selector_url = Selector::parse("div.data a, div.post-title a, div.item-thumb a")
             .map_err(|e| anyhow!("failed to parse selector: {:?}", e))?;
@@ -264,9 +264,12 @@ fn parse_chapters(
                 title: chapter_name.clone(),
                 path: el
                     .select(selector_chapter_url)
-                    .filter_map(|el| el.value().attr("href"))
-                    .collect::<Vec<&str>>()
-                    .join("")
+                    .next()
+                    .unwrap()
+                    .value()
+                    .attr("href")
+                    .unwrap()
+                    .to_string()
                     .replace(url, ""),
                 number: chapter_name
                     .replace("Chapter ", "")
@@ -277,8 +280,8 @@ fn parse_chapters(
                     &format!("{} 00:00", chapter_time.trim()),
                     "%B %d, %Y %H:%M",
                 )
-                .unwrap_or_else(|_| Utc::now().naive_utc())
-                .timestamp(),
+                    .unwrap_or_else(|_| Utc::now().naive_utc())
+                    .timestamp(),
             }
         })
         .collect();

--- a/extensions/1stkissmanhua/Cargo.toml
+++ b/extensions/1stkissmanhua/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "firstkissmanhua"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [lib]

--- a/extensions/isekaiscan/Cargo.toml
+++ b/extensions/isekaiscan/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "isekaiscan"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [lib]

--- a/extensions/leviatanscan/Cargo.toml
+++ b/extensions/leviatanscan/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leviatanscan"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [lib]

--- a/extensions/mangatx/Cargo.toml
+++ b/extensions/mangatx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mangatx"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [lib]

--- a/extensions/manhuafast/Cargo.toml
+++ b/extensions/manhuafast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "manhuafast"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [lib]

--- a/extensions/manhwa18cc/Cargo.toml
+++ b/extensions/manhwa18cc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "manhwa18cc"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 
 [lib]

--- a/extensions/mmscans/Cargo.toml
+++ b/extensions/mmscans/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mmscans"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [lib]

--- a/extensions/reaperscan/Cargo.toml
+++ b/extensions/reaperscan/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "reaperscan"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [lib]

--- a/extensions/tritiniascans/Cargo.toml
+++ b/extensions/tritiniascans/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tritiniascans"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
Fixes latest chapter URLs that was broken on some Madara websites, and manga's name that wasn't showing correctly.